### PR TITLE
Update for SEP-1865 stable spec + submission readiness tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,8 @@ Your app is production-ready.
   - `server/tests/chatgpt_app_guidelines_report.txt`
   - `server/tests/output_quality_report.txt`
   - `server/tests/agentic_ux_patterns_report.txt`
+  - `server/tests/protocol_compliance_report.txt`
+  - `server/tests/app_submission_report.txt`
 
 ### Ask First
 - Adding new npm dependencies (especially heavy ones like `three`, `chart.js`)

--- a/internal/apptester/McpAppRenderer.tsx
+++ b/internal/apptester/McpAppRenderer.tsx
@@ -63,17 +63,32 @@ interface JsonRpcMessage {
   error?: { code: number; message: string; data?: unknown };
 }
 
-// Get sandbox proxy URL based on current host
+// Detect whether we're running on localhost with direct port access.
+// In local dev, the sandbox proxy runs on a dedicated port (8001) for
+// origin isolation. Behind reverse proxies (Cloudflare Tunnel, nginx,
+// cloud platforms, etc.) port 8001 is typically not exposed, so we fall
+// back to a same-origin /sandbox/ path served by the main server.
+function isLocalDev(): boolean {
+  const origin = window.location.origin;
+  return origin.includes("localhost:8000") || origin.includes("127.0.0.1:8000");
+}
+
+// Get sandbox proxy base URL for building iframe src
 function getSandboxProxyUrl(): string {
-  const baseUrl = window.location.origin;
-  // Replace port with 8001 for sandbox server
-  if (baseUrl.includes(":8000")) {
-    return baseUrl.replace(":8000", ":8001");
+  if (isLocalDev()) {
+    return window.location.origin.replace(":8000", ":8001");
   }
-  // For other ports or no port, assume 8001
-  const url = new URL(baseUrl);
-  url.port = "8001";
-  return url.origin;
+  // Same-origin fallback: sandbox proxy served at /sandbox/ on the main server
+  return `${window.location.origin}/sandbox`;
+}
+
+// Get the origin of the sandbox proxy (for postMessage targetOrigin).
+// postMessage requires a bare origin (scheme+host+port), not a URL path.
+function getSandboxProxyOrigin(): string {
+  if (isLocalDev()) {
+    return window.location.origin.replace(":8000", ":8001");
+  }
+  return window.location.origin;
 }
 
 let messageIdCounter = 0;
@@ -100,7 +115,7 @@ export default function McpAppRenderer({
     const iframe = iframeRef.current;
     if (!iframe?.contentWindow) return;
 
-    const sandboxOrigin = getSandboxProxyUrl();
+    const sandboxOrigin = getSandboxProxyOrigin();
     iframe.contentWindow.postMessage(message, sandboxOrigin);
   }, []);
 
@@ -197,7 +212,7 @@ export default function McpAppRenderer({
       if (!iframe) return;
 
       // Accept messages from sandbox proxy origin
-      const sandboxOrigin = getSandboxProxyUrl();
+      const sandboxOrigin = getSandboxProxyOrigin();
       // Also accept 'null' origin from srcdoc iframes
       if (event.origin !== sandboxOrigin && event.origin !== "null" && !event.origin.includes("localhost")) {
         return;

--- a/internal/apptester/McpAppRenderer.tsx
+++ b/internal/apptester/McpAppRenderer.tsx
@@ -401,7 +401,12 @@ export default function McpAppRenderer({
     }
   }, [theme, displayMode, appInitialized, sendNotification, buildHostContext]);
 
-  // Build sandbox proxy URL with CSP parameters
+  // Build sandbox proxy URL with CSP parameters.
+  // SECURITY NOTE: In same-origin mode (behind reverse proxies), the sandbox
+  // iframe shares the host origin. Combined with allow-scripts + allow-same-origin,
+  // widgets could theoretically escape the sandbox. This is acceptable for the
+  // app tester (a local dev tool testing your own widgets) but production MCP
+  // Apps hosts (ChatGPT, Claude, VS Code) use dedicated sandbox origins.
   const sandboxProxyUrl = `${getSandboxProxyUrl()}/sandbox-proxy.html`;
 
   return (

--- a/internal/sandbox-proxy/index.tsx
+++ b/internal/sandbox-proxy/index.tsx
@@ -37,15 +37,20 @@ interface JsonRpcMessage {
   error?: unknown;
 }
 
-// Get the host origin from the parent window
+// Get the host origin from the parent window.
+// In local dev, the sandbox runs on port 8001 and the host on port 8000.
+// Behind reverse proxies, both share the same origin (served at /sandbox/).
 function getHostOrigin(): string {
-  // In development, the host is on port 8000
-  // The referrer tells us where we came from
+  // Referrer is the most reliable signal — the parent page that loaded us
   if (document.referrer) {
     const url = new URL(document.referrer);
     return url.origin;
   }
-  // Fallback: assume same host, different port
+  // Same-origin mode: sandbox proxy served at /sandbox/ on the main server
+  if (window.location.pathname.startsWith("/sandbox/")) {
+    return window.location.origin;
+  }
+  // Fallback: localhost dev — sandbox on 8001, host on 8000
   return window.location.origin.replace(":8001", ":8000");
 }
 

--- a/server/main.py
+++ b/server/main.py
@@ -39,7 +39,7 @@ from widgets import (
 from widgets._base import (
     Widget, ASSETS_DIR, MIME_TYPE,
     load_widget_html, get_base_url, get_csp_domains,
-    get_tool_meta, get_invocation_meta, get_tool_schema,
+    get_tool_meta, get_data_only_tool_meta, get_invocation_meta, get_tool_schema,
     format_validation_error,
     EXTERNAL_RESOURCE_DOMAINS, EXTERNAL_CONNECT_DOMAINS,
 )
@@ -110,24 +110,26 @@ async def list_tools() -> List[types.Tool]:
             inputSchema=schema,
             _meta=get_tool_meta(widget),
             annotations={
-                "destructiveHint": False,
-                "openWorldHint": False,
-                "readOnlyHint": True,
+                "readOnlyHint": widget.read_only,
+                "destructiveHint": widget.destructive,
+                "openWorldHint": widget.open_world,
             },
         ))
 
     # Data-only tools: called by widgets via callTool, not intended for LLM use.
     # They must be registered so MCP hosts can route callTool invocations.
+    # visibility=["app"] hides them from the model (SEP-1865).
     for tool_def in DATA_ONLY_TOOL_DEFS:
         tools.append(types.Tool(
             name=tool_def["name"],
             title=tool_def["title"],
             description=tool_def["description"],
             inputSchema=tool_def["inputSchema"],
+            _meta=get_data_only_tool_meta(),
             annotations={
-                "destructiveHint": False,
-                "openWorldHint": False,
-                "readOnlyHint": True,
+                "readOnlyHint": tool_def.get("readOnlyHint", True),
+                "destructiveHint": tool_def.get("destructiveHint", False),
+                "openWorldHint": tool_def.get("openWorldHint", False),
             },
         ))
 

--- a/server/main.py
+++ b/server/main.py
@@ -266,7 +266,7 @@ except Exception:
 # =============================================================================
 
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, HTMLResponse, Response
 from starlette.routing import Route
 import json as json_module
 
@@ -469,6 +469,68 @@ app.routes.append(Route("/chat/reset", reset_chat_endpoint, methods=["POST"]))
 app.routes.append(Route("/chat/status", chat_status_endpoint, methods=["GET"]))
 app.routes.append(Route("/tools", tools_list_endpoint, methods=["GET"]))
 app.routes.append(Route("/tools/call", tool_call_endpoint, methods=["POST"]))
+
+
+# =============================================================================
+# SAME-ORIGIN SANDBOX PROXY (for reverse-proxy environments)
+# =============================================================================
+# In local dev, the sandbox proxy runs on port 8001 for origin isolation.
+# Behind reverse proxies (Cloudflare Tunnel, nginx, cloud platforms, etc.),
+# port 8001 is often not exposed or the proxy injects its own CSP that blocks
+# cross-port iframes. This route serves the sandbox proxy from the same origin
+# (port 8000) at /sandbox/ as a spec-compliant fallback. The iframe sandbox
+# attribute still provides sandboxing per SEP-1865.
+
+async def sandbox_proxy_endpoint(request: Request) -> Response:
+    """Serve sandbox proxy assets with appropriate CSP from the main server.
+
+    Only serves files that start with 'sandbox-proxy' to prevent this route
+    from becoming a general-purpose static file server.
+    """
+    filename = request.path_params.get("filename", "sandbox-proxy.html")
+
+    # Security: only serve sandbox-proxy files, prevent path traversal
+    if ".." in filename or "/" in filename or not filename.startswith("sandbox-proxy"):
+        return Response("Forbidden", status_code=403)
+
+    filepath = ASSETS_DIR / filename
+    if not filepath.exists() or not filepath.is_file():
+        return Response("Not found", status_code=404)
+
+    content = filepath.read_text()
+    content_type = "text/html" if filename.endswith(".html") else \
+                   "application/javascript" if filename.endswith(".js") else \
+                   "text/css" if filename.endswith(".css") else "application/octet-stream"
+
+    # Build CSP for the sandbox
+    csp_domains = get_csp_domains()
+    resource_domains = csp_domains.get("resourceDomains", [])
+    connect_domains = csp_domains.get("connectDomains", [])
+    resource_src = " ".join(resource_domains) if resource_domains else "'self'"
+    connect_src = " ".join(connect_domains) if connect_domains else "'self'"
+
+    csp = (
+        f"default-src 'self'; "
+        f"script-src 'self' 'unsafe-inline' 'unsafe-eval' blob: {resource_src}; "
+        f"style-src 'self' 'unsafe-inline' {resource_src}; "
+        f"img-src 'self' data: blob: {resource_src}; "
+        f"font-src 'self' data: {resource_src}; "
+        f"connect-src 'self' {connect_src}; "
+        f"frame-src 'self' blob:; "
+        f"worker-src 'self' blob: {resource_src};"
+    )
+
+    return Response(
+        content=content,
+        media_type=content_type,
+        headers={
+            "Content-Security-Policy": csp,
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            "Access-Control-Allow-Origin": "*",
+        },
+    )
+
+app.routes.append(Route("/sandbox/{filename:path}", sandbox_proxy_endpoint, methods=["GET", "OPTIONS"]))
 
 
 # =============================================================================

--- a/server/tests/test_app_submission.py
+++ b/server/tests/test_app_submission.py
@@ -1,0 +1,783 @@
+"""
+App Submission Readiness Tests.
+
+These tests verify the MCP server meets requirements for publishing to
+app stores like OpenAI's ChatGPT Apps marketplace.
+
+Based on:
+- OpenAI App Submission Guidelines (developers.openai.com/apps-sdk/app-submission-guidelines)
+- "What Makes a Great ChatGPT App" (developers.openai.com/blog/what-makes-a-great-chatgpt-app)
+- "15 Lessons Building ChatGPT Apps" (docs/15-lessons-building-chatgpt-apps.md)
+- MCP Apps GA announcement (blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/)
+
+Categories tested:
+1. Annotation Correctness - Top rejection reason per OpenAI
+2. Stability & Reliability - No crashes, consistent responses
+3. Token Efficiency - Responses fit in context windows
+4. Capability Focus - Think capabilities, not screens
+5. Cold Start Experience - Value on first interaction
+6. Cross-Host Portability - Works on ChatGPT, Claude, VS Code, etc.
+"""
+
+import json
+import time
+import pytest
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import mcp.types as types
+
+
+# =============================================================================
+# GRADING INFRASTRUCTURE
+# =============================================================================
+
+@dataclass
+class GradeResult:
+    """Result of a submission readiness check."""
+    category: str
+    check_name: str
+    passed: bool
+    score: float
+    details: str
+    weight: float = 1.0
+    fix_hint: str = ""
+
+
+class AppSubmissionReport:
+    """Collects submission readiness results and generates a report."""
+
+    def __init__(self):
+        self.results: List[GradeResult] = []
+
+    def add_result(self, result: GradeResult):
+        self.results.append(result)
+
+    def get_category_score(self, category: str) -> float:
+        category_results = [r for r in self.results if r.category == category]
+        if not category_results:
+            return 0.0
+        total_weight = sum(r.weight for r in category_results)
+        weighted_sum = sum(r.score * r.weight for r in category_results)
+        return (weighted_sum / total_weight) * 100 if total_weight > 0 else 0.0
+
+    def get_overall_score(self) -> float:
+        if not self.results:
+            return 0.0
+        total_weight = sum(r.weight for r in self.results)
+        weighted_sum = sum(r.score * r.weight for r in self.results)
+        return (weighted_sum / total_weight) * 100 if total_weight > 0 else 0.0
+
+    def get_grade_letter(self) -> str:
+        score = self.get_overall_score()
+        if score >= 90: return "A"
+        elif score >= 80: return "B"
+        elif score >= 70: return "C"
+        elif score >= 60: return "D"
+        else: return "F"
+
+    def generate_report(self) -> str:
+        lines = [
+            "=" * 60,
+            "APP SUBMISSION READINESS REPORT",
+            "=" * 60,
+            "",
+            "Based on: OpenAI App Submission Guidelines +",
+            "          MCP Apps Best Practices (2025-2026)",
+            "",
+        ]
+
+        categories: Dict[str, List[GradeResult]] = {}
+        for r in self.results:
+            categories.setdefault(r.category, []).append(r)
+
+        for category, results in sorted(categories.items()):
+            score = self.get_category_score(category)
+            lines.append(f"\n{category}: {score:.1f}%")
+            lines.append("-" * 40)
+            for r in results:
+                status = "\u2713" if r.passed else "\u2717"
+                lines.append(f"  {status} {r.check_name}: {r.score*100:.0f}%")
+                if not r.passed:
+                    if r.fix_hint:
+                        lines.append(f"      FIX: {r.fix_hint}")
+                    if r.details:
+                        for detail_line in r.details.split("\n")[:5]:
+                            lines.append(f"      {detail_line}")
+
+        lines.append("\n" + "=" * 60)
+        overall = self.get_overall_score()
+        grade = self.get_grade_letter()
+        lines.append(f"OVERALL SCORE: {overall:.1f}% (Grade: {grade})")
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+
+_report = AppSubmissionReport()
+
+
+# =============================================================================
+# 1. ANNOTATION CORRECTNESS TESTS
+# =============================================================================
+
+class TestAnnotationCorrectness:
+    """Tests for correct tool annotations.
+
+    From OpenAI's App Submission Guidelines:
+    "Tool annotations must be correctly set - incorrect/missing annotations
+    are a common rejection reason."
+
+    Key rules:
+    - readOnlyHint=True means the tool ONLY reads data (no writes)
+    - destructiveHint=True means the tool deletes/irreversibly changes data
+    - openWorldHint=True means the tool accesses external third-party APIs
+    - readOnlyHint and destructiveHint should never BOTH be True
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_conflicting_annotations(self):
+        """readOnlyHint and destructiveHint should never both be True."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+
+        for tool in tools:
+            annotations = getattr(tool, 'annotations', None) or {}
+            if isinstance(annotations, dict):
+                anno_dict = annotations
+            elif hasattr(annotations, 'model_dump'):
+                anno_dict = annotations.model_dump()
+            else:
+                continue
+
+            is_read_only = anno_dict.get("readOnlyHint", False)
+            is_destructive = anno_dict.get("destructiveHint", False)
+
+            if is_read_only and is_destructive:
+                violations.append(
+                    f"'{tool.name}' - conflicting: readOnlyHint=True AND destructiveHint=True"
+                )
+
+        score = 1.0 if len(violations) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="1. Annotation Correctness",
+            check_name="No conflicting annotations",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=2.0,
+            fix_hint="A tool can't be both read-only and destructive. Pick one.",
+        ))
+
+        assert len(violations) == 0, f"Conflicting annotations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_annotations_match_description(self):
+        """Annotations should be consistent with tool description.
+
+        If a tool says "delete" or "remove" in its description, it should
+        have destructiveHint=True. If it says "display" or "show", it
+        should have readOnlyHint=True.
+
+        TODO: Improve with LLM. Current implementation uses keyword matching.
+        An LLM could better understand nuanced descriptions.
+        """
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+
+        destructive_keywords = ['delete', 'remove', 'destroy', 'drop', 'erase', 'purge']
+        read_only_keywords = ['display', 'show', 'view', 'render', 'visualize', 'present', 'list', 'get']
+        external_keywords = ['external api', 'third-party', 'fetch from', 'calls to', 'connects to']
+
+        for tool in tools:
+            annotations = getattr(tool, 'annotations', None) or {}
+            if isinstance(annotations, dict):
+                anno_dict = annotations
+            elif hasattr(annotations, 'model_dump'):
+                anno_dict = annotations.model_dump()
+            else:
+                continue
+
+            desc_lower = tool.description.lower()
+
+            # Check destructive mismatch
+            mentions_destructive = any(kw in desc_lower for kw in destructive_keywords)
+            is_destructive = anno_dict.get("destructiveHint", False)
+            if mentions_destructive and not is_destructive:
+                violations.append(
+                    f"'{tool.name}' - description mentions destructive action but destructiveHint=False"
+                )
+
+            # Check read-only mismatch
+            mentions_read_only = any(kw in desc_lower for kw in read_only_keywords)
+            is_read_only = anno_dict.get("readOnlyHint", False)
+            if mentions_read_only and not mentions_destructive and not is_read_only:
+                # Only flag if it's clearly read-only (no destructive terms)
+                violations.append(
+                    f"'{tool.name}' - description suggests read-only but readOnlyHint=False"
+                )
+
+        score = 1.0 - (len(violations) / len(tools)) if tools else 0.0
+        _report.add_result(GradeResult(
+            category="1. Annotation Correctness",
+            check_name="Annotations match description",
+            passed=len(violations) == 0,
+            score=max(0, score),
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Align annotations with what the tool actually does",
+        ))
+
+
+# =============================================================================
+# 2. STABILITY & RELIABILITY TESTS
+# =============================================================================
+
+class TestStabilityReliability:
+    """Tests for server stability.
+
+    From OpenAI's guidelines:
+    "Apps must be thoroughly tested for stability, responsiveness, and low latency."
+    "Common rejection: review team cannot connect to MCP server."
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_tools_respond_without_crash(self):
+        """Every tool MUST return a valid response (not crash) with default args."""
+        from main import handle_call_tool, WIDGETS
+
+        crashes = []
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+
+            try:
+                result = await handle_call_tool(request)
+                # Should have either content or structuredContent
+                has_content = bool(result.root.content)
+                has_structured = result.root.structuredContent is not None
+                if not has_content and not has_structured:
+                    crashes.append(f"'{widget.identifier}' - returns empty result")
+            except Exception as e:
+                crashes.append(f"'{widget.identifier}' - CRASHED: {type(e).__name__}: {e}")
+
+        score = 1.0 - (len(crashes) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="2. Stability & Reliability",
+            check_name="No crashes with default args",
+            passed=len(crashes) == 0,
+            score=score,
+            details="\n".join(crashes) if crashes else f"All {len(WIDGETS)} tools respond successfully",
+            weight=2.0,
+            fix_hint="Wrap handler logic in try/except and return error result instead of crashing",
+        ))
+
+        assert len(crashes) == 0, f"Tool crashes:\n" + "\n".join(crashes)
+
+    @pytest.mark.asyncio
+    async def test_all_tools_handle_invalid_input(self):
+        """Every tool MUST gracefully handle invalid input (not crash)."""
+        from main import handle_call_tool, WIDGETS
+
+        crashes = []
+
+        invalid_inputs = [
+            {"completely_invalid_field_xyz": "bad"},
+            {"": "empty key"},
+            {"x" * 1000: "very long key"},
+        ]
+
+        for widget in WIDGETS:
+            for invalid in invalid_inputs:
+                request = types.CallToolRequest(
+                    method="tools/call",
+                    params=types.CallToolRequestParams(
+                        name=widget.identifier,
+                        arguments=invalid,
+                    ),
+                )
+
+                try:
+                    result = await handle_call_tool(request)
+                    # Should be an error, not success
+                    if not result.root.isError:
+                        # Accepting invalid input without error is a minor issue
+                        pass
+                except Exception as e:
+                    crashes.append(
+                        f"'{widget.identifier}' - CRASHED on {list(invalid.keys())[0][:20]}: {type(e).__name__}"
+                    )
+
+        score = 1.0 if len(crashes) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="2. Stability & Reliability",
+            check_name="Graceful invalid input handling",
+            passed=len(crashes) == 0,
+            score=score,
+            details="\n".join(crashes) if crashes else "",
+            weight=2.0,
+            fix_hint="Use Pydantic extra='forbid' and try/except ValidationError in handlers",
+        ))
+
+        assert len(crashes) == 0, f"Crashes on invalid input:\n" + "\n".join(crashes)
+
+
+# =============================================================================
+# 3. TOKEN EFFICIENCY TESTS
+# =============================================================================
+
+class TestTokenEfficiency:
+    """Tests for token-efficient responses.
+
+    From Anthropic's "Code Execution with MCP" blog post:
+    "Too many connected MCP servers causes tool definitions and results to
+    consume excessive tokens, reducing agent efficiency."
+
+    From OpenAI's "What Makes a Great ChatGPT App":
+    "Return lean, model-friendly outputs."
+
+    Key metrics:
+    - Tool descriptions should be informative but not bloated
+    - Responses should be compact (structuredContent is NOT in model context,
+      but content[] text IS)
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_descriptions_not_bloated(self):
+        """Tool descriptions should be < 2000 chars (informative but compact)."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+        MAX_DESC = 2000
+
+        for tool in tools:
+            if len(tool.description) > MAX_DESC:
+                violations.append(
+                    f"'{tool.name}' - description {len(tool.description)} chars (max {MAX_DESC})"
+                )
+
+        score = 1.0 - (len(violations) / len(tools)) if tools else 0.0
+        _report.add_result(GradeResult(
+            category="3. Token Efficiency",
+            check_name="Compact tool descriptions",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Keep descriptions under 2000 chars. Move detailed docs to server instructions.",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_text_content_is_concise(self):
+        """Text fallback content should be concise (under 500 chars).
+
+        The text in content[] is added to the model's context. Large text
+        wastes tokens. Use structuredContent for detailed data.
+        """
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+        MAX_TEXT = 500
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            for c in (result.root.content or []):
+                if getattr(c, 'type', None) == 'text':
+                    text = getattr(c, 'text', '')
+                    if len(text) > MAX_TEXT:
+                        violations.append(
+                            f"'{widget.identifier}' - text content {len(text)} chars (max {MAX_TEXT})"
+                        )
+
+        score = 1.0 - (len(violations) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="3. Token Efficiency",
+            check_name="Concise text content",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.2,
+            fix_hint="Keep text content under 500 chars. Put detailed data in structuredContent.",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_input_schema_not_bloated(self):
+        """Input schemas should be compact (< 20 parameters per tool).
+
+        Large schemas consume tokens in the model's context and increase
+        confusion about which params to use.
+        """
+        from main import list_tools
+
+        tools = await list_tools()
+        MAX_PARAMS = 20
+        violations = []
+
+        for tool in tools:
+            if tool.inputSchema:
+                props = tool.inputSchema.get("properties", {})
+                if len(props) > MAX_PARAMS:
+                    violations.append(
+                        f"'{tool.name}' - {len(props)} params (max {MAX_PARAMS})"
+                    )
+
+        score = 1.0 - (len(violations) / len(tools)) if tools else 0.0
+        _report.add_result(GradeResult(
+            category="3. Token Efficiency",
+            check_name="Compact input schemas",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=0.8,
+            fix_hint="Reduce params: group related fields, use sensible defaults, remove rarely-used options",
+        ))
+
+        assert len(violations) == 0, f"Bloated schemas:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 4. CAPABILITY FOCUS TESTS
+# =============================================================================
+
+class TestCapabilityFocus:
+    """Tests for capability-focused design.
+
+    From OpenAI's "What Makes a Great ChatGPT App":
+    "Think capabilities, not screens. Users are mid-conversation; the model
+    decides when to invoke your app. Best apps expose a few specific powers,
+    not entire product replicas."
+
+    Tests verify that tools are focused capabilities, not kitchen-sink APIs.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tools_are_focused(self):
+        """Each tool should do ONE thing well (not multiple unrelated things)."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+
+        # Multi-purpose indicators in description
+        multi_purpose = [
+            'and also', 'additionally handles', 'can also be used to',
+            'serves double duty', 'multi-purpose', 'all-in-one'
+        ]
+
+        for tool in tools:
+            desc_lower = tool.description.lower()
+            for pattern in multi_purpose:
+                if pattern in desc_lower:
+                    violations.append(f"'{tool.name}' - description suggests multi-purpose: '{pattern}'")
+                    break
+
+        score = 1.0 - (len(violations) / len(tools)) if tools else 0.0
+        _report.add_result(GradeResult(
+            category="4. Capability Focus",
+            check_name="Single-purpose tools",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Split multi-purpose tools into separate focused tools",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_tool_count_appropriate(self):
+        """App should have a focused set of tools (3-15 is ideal).
+
+        From OpenAI: "Best apps expose a few specific powers, not entire
+        product replicas."
+        """
+        from main import list_tools
+
+        tools = await list_tools()
+        count = len(tools)
+
+        if count <= 7:
+            score = 1.0
+            details = f"Excellent: {count} tools (focused utility)"
+        elif count <= 15:
+            score = 0.9
+            details = f"Good: {count} tools (reasonable scope)"
+        elif count <= 25:
+            score = 0.7
+            details = f"Acceptable: {count} tools (consider pruning)"
+        else:
+            score = 0.4
+            details = f"Too many: {count} tools (split into separate servers)"
+
+        _report.add_result(GradeResult(
+            category="4. Capability Focus",
+            check_name="Focused tool count",
+            passed=count <= 25,
+            score=score,
+            details=details,
+            weight=0.8,
+            fix_hint="Keep 3-15 tools. Split large servers into focused modules.",
+        ))
+
+
+# =============================================================================
+# 5. COLD START EXPERIENCE TESTS
+# =============================================================================
+
+class TestColdStartExperience:
+    """Tests for first-interaction experience.
+
+    From OpenAI's "What Makes a Great ChatGPT App":
+    "Deliver value quickly. Produce something concrete fast. Multi-step
+    onboarding kills engagement."
+
+    Tools should work immediately with no setup, no auth, no configuration.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_tools_work_with_empty_args(self):
+        """Every tool should produce useful output with {} arguments."""
+        from main import handle_call_tool, WIDGETS
+
+        failures = []
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            if result.root.isError:
+                failures.append(f"'{widget.identifier}' - errors with empty args")
+            elif not result.root.structuredContent:
+                failures.append(f"'{widget.identifier}' - empty structuredContent with no args")
+
+        score = 1.0 - (len(failures) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="5. Cold Start Experience",
+            check_name="Works with empty arguments",
+            passed=len(failures) == 0,
+            score=score,
+            details="\n".join(failures) if failures else f"All {len(WIDGETS)} tools work with no args",
+            weight=2.0,
+            fix_hint="Provide default sample data so tools show useful content on first call",
+        ))
+
+        assert len(failures) == 0, f"Cold start failures:\n" + "\n".join(failures)
+
+    @pytest.mark.asyncio
+    async def test_default_output_has_real_content(self):
+        """Default output should have real content, not placeholders.
+
+        Users should see something meaningful on the first interaction,
+        not 'Loading...' or 'No data available'.
+        """
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+        placeholder_patterns = [
+            'loading', 'no data', 'no results', 'empty', 'placeholder',
+            'coming soon', 'todo', 'tbd', 'n/a', 'none available'
+        ]
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            if result.root.structuredContent:
+                content_str = json.dumps(result.root.structuredContent).lower()
+                for pattern in placeholder_patterns:
+                    # Only flag if it's a primary value, not part of a longer string
+                    if f'"{pattern}"' in content_str:
+                        violations.append(
+                            f"'{widget.identifier}' - contains placeholder value: '{pattern}'"
+                        )
+                        break
+
+        score = 1.0 - (len(violations) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="5. Cold Start Experience",
+            check_name="Real content, not placeholders",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Return real sample/demo data as defaults, not placeholder text",
+        ))
+
+
+# =============================================================================
+# 6. CROSS-HOST PORTABILITY TESTS
+# =============================================================================
+
+class TestCrossHostPortability:
+    """Tests for cross-host compatibility.
+
+    From the MCP Apps GA announcement:
+    "Supported by ChatGPT, Claude, Goose, and VS Code at launch."
+
+    From OpenAI's guidelines:
+    "Build for portability. Use the MCP Apps standard as the base, then
+    layer host-specific extensions on top."
+
+    Tests verify the server doesn't depend on host-specific features.
+    """
+
+    @pytest.mark.asyncio
+    async def test_no_host_specific_assumptions(self):
+        """Tool results should not reference host-specific APIs."""
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+        # Host-specific patterns that indicate non-portable code
+        host_specific = [
+            'chatgpt.com', 'claude.ai', 'openai.com/chat',
+            'window.chatgpt', 'window.claude',
+        ]
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            if result.root.structuredContent:
+                content_str = json.dumps(result.root.structuredContent).lower()
+                for pattern in host_specific:
+                    if pattern in content_str:
+                        violations.append(
+                            f"'{widget.identifier}' - references host-specific: '{pattern}'"
+                        )
+
+        score = 1.0 if len(violations) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="6. Cross-Host Portability",
+            check_name="No host-specific references",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Remove references to specific hosts. Use standard MCP Apps APIs only.",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_structured_content_is_json_serializable(self):
+        """structuredContent MUST be JSON-serializable for all hosts."""
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            if result.root.structuredContent:
+                try:
+                    json.dumps(result.root.structuredContent)
+                except (TypeError, ValueError) as e:
+                    violations.append(
+                        f"'{widget.identifier}' - not JSON-serializable: {e}"
+                    )
+
+        score = 1.0 if len(violations) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="6. Cross-Host Portability",
+            check_name="JSON-serializable output",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Ensure all values are JSON-compatible (no datetime objects, sets, etc.)",
+        ))
+
+        assert len(violations) == 0, f"Serialization errors:\n" + "\n".join(violations)
+
+    def test_server_has_stateless_mode(self):
+        """Server SHOULD support stateless HTTP for scalability.
+
+        From the 2026 MCP Roadmap: "Vision: stateless protocol enabling
+        scale, with stateful application sessions on top."
+        """
+        from main import mcp
+
+        # Check if stateless_http is enabled
+        is_stateless = getattr(mcp, '_stateless', None) or True  # Default assumption
+        # Check mcp server config
+        server = getattr(mcp, '_mcp_server', None)
+
+        _report.add_result(GradeResult(
+            category="6. Cross-Host Portability",
+            check_name="Stateless HTTP support",
+            passed=True,  # Informational
+            score=1.0,
+            details="Server supports stateless HTTP" if is_stateless else "Consider enabling stateless_http=True",
+            weight=0.5,
+            fix_hint="Set stateless_http=True in FastMCP() for better scalability",
+        ))
+
+
+# =============================================================================
+# REPORT GENERATION
+# =============================================================================
+
+class TestGenerateReport:
+    """Final test to generate the submission readiness report."""
+
+    def test_zzz_generate_app_submission_report(self, capsys):
+        """Generate final submission readiness report."""
+        report = _report.generate_report()
+        print("\n" + report)
+
+        report_path = Path(__file__).parent / "app_submission_report.txt"
+        report_path.write_text(report)
+
+        overall = _report.get_overall_score()
+        grade = _report.get_grade_letter()
+
+        # Submission readiness should be C or better (70%)
+        assert overall >= 70, f"""
+APP SUBMISSION READINESS: {grade} ({overall:.1f}%) - Below 70% threshold
+This means the app may be rejected during review.
+Report: server/tests/app_submission_report.txt
+Ref: developers.openai.com/apps-sdk/app-submission-guidelines
+"""

--- a/server/tests/test_app_submission.py
+++ b/server/tests/test_app_submission.py
@@ -20,7 +20,6 @@ Categories tested:
 """
 
 import json
-import time
 import pytest
 import sys
 from dataclasses import dataclass
@@ -207,8 +206,13 @@ class TestAnnotationCorrectness:
 
             desc_lower = tool.description.lower()
 
-            # Check destructive mismatch
-            mentions_destructive = any(kw in desc_lower for kw in destructive_keywords)
+            # Check destructive mismatch — only flag if the destructive keyword
+            # appears in the primary description or use-case sections, not in
+            # the "Returns:" or "features" sections where it describes client-side
+            # UI capabilities (e.g. "Add/edit/delete functionality" in a todo widget
+            # is a UI feature, not a server-side destructive action).
+            primary_desc = desc_lower.split("returns:")[0].split("returns\n")[0]
+            mentions_destructive = any(kw in primary_desc for kw in destructive_keywords)
             is_destructive = anno_dict.get("destructiveHint", False)
             if mentions_destructive and not is_destructive:
                 violations.append(
@@ -234,6 +238,11 @@ class TestAnnotationCorrectness:
             weight=1.5,
             fix_hint="Align annotations with what the tool actually does",
         ))
+
+        assert len(violations) == 0, (
+            f"Annotation/description mismatches (top rejection reason):\n"
+            + "\n".join(violations)
+        )
 
 
 # =============================================================================
@@ -740,17 +749,25 @@ class TestCrossHostPortability:
         """
         from main import mcp
 
-        # Check if stateless_http is enabled
-        is_stateless = getattr(mcp, '_stateless', None) or True  # Default assumption
-        # Check mcp server config
-        server = getattr(mcp, '_mcp_server', None)
+        # Check if stateless_http was enabled in FastMCP config.
+        # FastMCP stores this as _stateless_http or on the settings object.
+        is_stateless = getattr(mcp, '_stateless_http', None)
+        if is_stateless is None:
+            # Fallback: check settings or _mcp_server attributes
+            settings = getattr(mcp, 'settings', None)
+            if settings:
+                is_stateless = getattr(settings, 'stateless_http', False)
+            else:
+                # Check if streamable_http_app exists (only created when stateless)
+                is_stateless = callable(getattr(mcp, 'streamable_http_app', None))
 
+        passed = bool(is_stateless)
         _report.add_result(GradeResult(
             category="6. Cross-Host Portability",
             check_name="Stateless HTTP support",
-            passed=True,  # Informational
-            score=1.0,
-            details="Server supports stateless HTTP" if is_stateless else "Consider enabling stateless_http=True",
+            passed=passed,
+            score=1.0 if passed else 0.3,
+            details="Server supports stateless HTTP" if passed else "stateless_http is not enabled",
             weight=0.5,
             fix_hint="Set stateless_http=True in FastMCP() for better scalability",
         ))

--- a/server/tests/test_mcp_apps_compliance.py
+++ b/server/tests/test_mcp_apps_compliance.py
@@ -209,17 +209,19 @@ class TestToolMetadataCompliance:
     @pytest.mark.asyncio
     async def test_widget_tools_have_metadata(self):
         """Widget tools returned by list_tools must have _meta with ui section.
-        Data-only helper tools (no UI) are excluded from this check."""
-        from main import list_tools
+        Data-only helper tools (visibility=["app"] only) are excluded from this check."""
+        from main import list_tools, WIDGETS_BY_ID
         widget_tools_found = 0
         for tool in await list_tools():
             meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
             if meta is None:
-                # Data-only helper tool — no UI metadata required
+                continue
+            # Skip data-only tools — they have _meta.ui.visibility but no resourceUri
+            if tool.name not in WIDGETS_BY_ID:
                 continue
             widget_tools_found += 1
             assert "ui" in meta, f"Tool '{tool.name}' has _meta but missing _meta.ui"
-            assert "resourceUri" in meta["ui"]
+            assert "resourceUri" in meta["ui"], f"Tool '{tool.name}' missing _meta.ui.resourceUri"
         assert widget_tools_found > 0, "Expected at least one widget tool with _meta.ui"
 
 

--- a/server/tests/test_mcp_best_practices.py
+++ b/server/tests/test_mcp_best_practices.py
@@ -137,11 +137,11 @@ _report = MCPBestPracticesReport()
 
 
 async def _get_widget_tools():
-    """Return only widget tools (with _meta.ui) from list_tools.
-    Excludes data-only helper tools that are widget-internal."""
-    from main import list_tools
+    """Return only widget tools (with _meta.ui.resourceUri) from list_tools.
+    Excludes data-only helper tools that have _meta.ui.visibility but no resourceUri."""
+    from main import list_tools, WIDGETS_BY_ID
     tools = await list_tools()
-    return [t for t in tools if getattr(t, '_meta', None) or getattr(t, 'meta', None)]
+    return [t for t in tools if t.name in WIDGETS_BY_ID]
 
 
 def grade_check(category: str, check_name: str, weight: float = 1.0):

--- a/server/tests/test_protocol_compliance.py
+++ b/server/tests/test_protocol_compliance.py
@@ -397,7 +397,11 @@ class TestToolVisibility:
             visibility = ui_meta.get("visibility", [])
             if "model" in visibility:
                 violations.append(
-                    f"'{tool.name}' - data-only tool should have visibility=['app'], not {visibility}"
+                    f"'{tool.name}' - data-only tool should not be visible to model, got {visibility}"
+                )
+            if "app" not in visibility:
+                violations.append(
+                    f"'{tool.name}' - data-only tool must include 'app' in visibility to remain callable by widgets, got {visibility}"
                 )
 
         if data_tools == 0:

--- a/server/tests/test_protocol_compliance.py
+++ b/server/tests/test_protocol_compliance.py
@@ -1,0 +1,910 @@
+"""
+MCP Apps Protocol Compliance Tests (SEP-1865).
+
+These tests verify that the MCP server conforms to the MCP Apps protocol
+specification (SEP-1865, stable version 2026-01-26).
+
+Unlike the "best practices" and "guidelines" tests which are aspirational
+grading, these tests enforce HARD compliance requirements. A tool that
+fails these tests will not work correctly in MCP Apps hosts (ChatGPT,
+Claude, VS Code, Goose, etc.).
+
+Categories tested:
+1. Resource Registration - ui:// scheme, MIME type, CSP domains
+2. Tool-UI Linkage - _meta.ui.resourceUri, nested structure
+3. Tool Visibility - visibility array for model/app routing
+4. Tool Annotations - readOnlyHint, destructiveHint, openWorldHint
+5. CSP Completeness - All four domain lists present
+6. Text Fallback - content[] provided alongside structuredContent
+7. Invocation Metadata - _meta in tool results
+
+References:
+- docs/mcp-apps-specs.mdx (SEP-1865 stable, 2026-01-26)
+- docs/mcp-apps-docs.md (MCP Apps overview)
+- https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/
+"""
+
+import json
+import pytest
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Set
+from urllib.parse import urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+import mcp.types as types
+
+
+# =============================================================================
+# GRADING INFRASTRUCTURE
+# =============================================================================
+
+@dataclass
+class GradeResult:
+    """Result of a compliance check."""
+    category: str
+    check_name: str
+    passed: bool
+    score: float  # 0.0 to 1.0
+    details: str
+    weight: float = 1.0
+    fix_hint: str = ""
+
+
+class ProtocolComplianceReport:
+    """Collects compliance results and generates a report."""
+
+    def __init__(self):
+        self.results: List[GradeResult] = []
+
+    def add_result(self, result: GradeResult):
+        self.results.append(result)
+
+    def get_category_score(self, category: str) -> float:
+        category_results = [r for r in self.results if r.category == category]
+        if not category_results:
+            return 0.0
+        total_weight = sum(r.weight for r in category_results)
+        weighted_sum = sum(r.score * r.weight for r in category_results)
+        return (weighted_sum / total_weight) * 100 if total_weight > 0 else 0.0
+
+    def get_overall_score(self) -> float:
+        if not self.results:
+            return 0.0
+        total_weight = sum(r.weight for r in self.results)
+        weighted_sum = sum(r.score * r.weight for r in self.results)
+        return (weighted_sum / total_weight) * 100 if total_weight > 0 else 0.0
+
+    def get_grade_letter(self) -> str:
+        score = self.get_overall_score()
+        if score >= 90: return "A"
+        elif score >= 80: return "B"
+        elif score >= 70: return "C"
+        elif score >= 60: return "D"
+        else: return "F"
+
+    def generate_report(self) -> str:
+        lines = [
+            "=" * 60,
+            "MCP APPS PROTOCOL COMPLIANCE REPORT",
+            "=" * 60,
+            "",
+            "Spec: SEP-1865 (stable, 2026-01-26)",
+            "",
+        ]
+
+        categories: Dict[str, List[GradeResult]] = {}
+        for r in self.results:
+            categories.setdefault(r.category, []).append(r)
+
+        for category, results in sorted(categories.items()):
+            score = self.get_category_score(category)
+            lines.append(f"\n{category}: {score:.1f}%")
+            lines.append("-" * 40)
+            for r in results:
+                status = "\u2713" if r.passed else "\u2717"
+                lines.append(f"  {status} {r.check_name}: {r.score*100:.0f}%")
+                if not r.passed:
+                    if r.fix_hint:
+                        lines.append(f"      FIX: {r.fix_hint}")
+                    if r.details:
+                        for detail_line in r.details.split("\n"):
+                            lines.append(f"      {detail_line}")
+
+        lines.append("\n" + "=" * 60)
+        overall = self.get_overall_score()
+        grade = self.get_grade_letter()
+        lines.append(f"OVERALL SCORE: {overall:.1f}% (Grade: {grade})")
+        lines.append("=" * 60)
+        return "\n".join(lines)
+
+
+_report = ProtocolComplianceReport()
+
+
+# =============================================================================
+# 1. RESOURCE REGISTRATION TESTS
+# =============================================================================
+
+class TestResourceRegistration:
+    """Tests that UI resources are correctly registered per SEP-1865.
+
+    MCP Apps resources MUST:
+    - Use the ui:// URI scheme
+    - Have MIME type text/html;profile=mcp-app
+    - Include _meta.ui with CSP configuration
+    """
+
+    @pytest.mark.asyncio
+    async def test_resources_use_ui_scheme(self):
+        """All UI resources MUST use the ui:// URI scheme."""
+        from main import list_resources
+
+        resources = await list_resources()
+        violations = []
+
+        for resource in resources:
+            uri = str(resource.uri)
+            if not uri.startswith("ui://"):
+                violations.append(f"'{resource.name}' - URI '{uri}' does not use ui:// scheme")
+
+        score = 1.0 - (len(violations) / len(resources)) if resources else 0.0
+        _report.add_result(GradeResult(
+            category="1. Resource Registration",
+            check_name="ui:// URI scheme",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {len(resources)} resources use ui:// scheme",
+            weight=2.0,
+            fix_hint="Set template_uri='ui://widget/my-widget.html' in Widget definition",
+        ))
+
+        assert len(violations) == 0, f"URI scheme violations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_resources_have_correct_mime_type(self):
+        """All UI resources MUST have MIME type text/html;profile=mcp-app."""
+        from main import list_resources
+
+        resources = await list_resources()
+        expected_mime = "text/html;profile=mcp-app"
+        violations = []
+
+        for resource in resources:
+            if resource.mimeType != expected_mime:
+                violations.append(
+                    f"'{resource.name}' - MIME '{resource.mimeType}' should be '{expected_mime}'"
+                )
+
+        score = 1.0 - (len(violations) / len(resources)) if resources else 0.0
+        _report.add_result(GradeResult(
+            category="1. Resource Registration",
+            check_name="MCP App MIME type",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=2.0,
+            fix_hint="Set MIME_TYPE = 'text/html;profile=mcp-app' in _base.py",
+        ))
+
+        assert len(violations) == 0, f"MIME type violations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_resources_have_meta_ui(self):
+        """Resources MUST have _meta.ui with CSP configuration."""
+        from main import list_resources
+
+        resources = await list_resources()
+        violations = []
+
+        for resource in resources:
+            meta = getattr(resource, '_meta', None) or getattr(resource, 'meta', None)
+            if not meta:
+                violations.append(f"'{resource.name}' - missing _meta")
+                continue
+
+            ui_meta = meta.get("ui") if isinstance(meta, dict) else None
+            if not ui_meta:
+                violations.append(f"'{resource.name}' - missing _meta.ui")
+                continue
+
+            if "csp" not in ui_meta:
+                violations.append(f"'{resource.name}' - missing _meta.ui.csp")
+
+        score = 1.0 - (len(violations) / len(resources)) if resources else 0.0
+        _report.add_result(GradeResult(
+            category="1. Resource Registration",
+            check_name="Resource _meta.ui present",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Return _meta={'ui': {'csp': get_csp_domains(), ...}} in list_resources",
+        ))
+
+        assert len(violations) == 0, f"Resource meta violations:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 2. TOOL-UI LINKAGE TESTS
+# =============================================================================
+
+class TestToolUILinkage:
+    """Tests that tools are correctly linked to UI resources.
+
+    Per SEP-1865, tools MUST use the nested _meta.ui structure:
+    - _meta.ui.resourceUri (NOT the deprecated _meta["ui/resourceUri"])
+    - _meta.ui.csp for Content Security Policy
+    """
+
+    @pytest.mark.asyncio
+    async def test_tools_have_nested_meta_ui(self):
+        """Widget tools MUST use nested _meta.ui.resourceUri (not flat format)."""
+        from main import list_tools, WIDGETS_BY_ID
+
+        tools = await list_tools()
+        violations = []
+        widget_tools = 0
+
+        for tool in tools:
+            # Skip data-only tools — they have _meta.ui.visibility but no resourceUri
+            if tool.name not in WIDGETS_BY_ID:
+                continue
+
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+
+            # Check for deprecated flat format
+            if "ui/resourceUri" in meta:
+                violations.append(
+                    f"'{tool.name}' - uses deprecated flat _meta['ui/resourceUri'], use _meta.ui.resourceUri"
+                )
+                widget_tools += 1
+                continue
+
+            ui_meta = meta.get("ui")
+            if ui_meta and isinstance(ui_meta, dict):
+                widget_tools += 1
+                if "resourceUri" not in ui_meta:
+                    violations.append(f"'{tool.name}' - _meta.ui missing 'resourceUri'")
+
+        score = 1.0 - (len(violations) / widget_tools) if widget_tools else 0.0
+        _report.add_result(GradeResult(
+            category="2. Tool-UI Linkage",
+            check_name="Nested _meta.ui structure",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {widget_tools} tools use _meta.ui.resourceUri",
+            weight=2.0,
+            fix_hint="Use _meta={'ui': {'resourceUri': 'ui://...', 'csp': {...}}} (nested, not flat)",
+        ))
+
+        assert len(violations) == 0, f"Meta structure violations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_tool_resource_uris_are_registered(self):
+        """Every tool's _meta.ui.resourceUri MUST match a registered resource."""
+        from main import list_tools, list_resources
+
+        tools = await list_tools()
+        resources = await list_resources()
+
+        registered_uris = {str(r.uri) for r in resources}
+        violations = []
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            resource_uri = ui_meta.get("resourceUri")
+            if resource_uri and resource_uri not in registered_uris:
+                violations.append(
+                    f"'{tool.name}' - resourceUri '{resource_uri}' not in registered resources"
+                )
+
+        score = 1.0 if len(violations) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="2. Tool-UI Linkage",
+            check_name="ResourceURIs match resources",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Ensure each tool's template_uri matches a Widget registered in the server",
+        ))
+
+        assert len(violations) == 0, f"Unregistered resource URIs:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 3. TOOL VISIBILITY TESTS
+# =============================================================================
+
+class TestToolVisibility:
+    """Tests for tool visibility control (SEP-1865).
+
+    The visibility array controls who can see and call a tool:
+    - ["model", "app"] (default): Both model and widgets can call it
+    - ["model"]: Only the model can call it (hidden from widget callTool)
+    - ["app"]: Only widgets can call it (hidden from model tool list)
+
+    Data-only helper tools (no UI) SHOULD have visibility=["app"] so the
+    model doesn't try to call them directly.
+    """
+
+    @pytest.mark.asyncio
+    async def test_widget_tools_have_visibility(self):
+        """Widget tools SHOULD declare visibility in _meta.ui."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+        widget_tools = 0
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            if "resourceUri" in ui_meta:
+                widget_tools += 1
+                if "visibility" not in ui_meta:
+                    violations.append(f"'{tool.name}' - missing _meta.ui.visibility")
+
+        score = 1.0 - (len(violations) / widget_tools) if widget_tools else 0.0
+        _report.add_result(GradeResult(
+            category="3. Tool Visibility",
+            check_name="Widget tools declare visibility",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {widget_tools} widget tools have visibility",
+            weight=1.5,
+            fix_hint="Add 'visibility': ['model', 'app'] to _meta.ui in get_tool_meta()",
+        ))
+
+        assert len(violations) == 0, f"Missing visibility:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_data_only_tools_have_app_visibility(self):
+        """Data-only tools (no UI) SHOULD have visibility=['app'].
+
+        This prevents the model from calling helper tools directly, which
+        would fail because they don't produce visual output.
+        """
+        from main import list_tools, WIDGETS_BY_ID
+
+        tools = await list_tools()
+        violations = []
+        data_tools = 0
+
+        for tool in tools:
+            # Skip widget tools
+            if tool.name in WIDGETS_BY_ID:
+                continue
+
+            data_tools += 1
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+
+            if not meta or not isinstance(meta, dict):
+                violations.append(f"'{tool.name}' - data-only tool missing _meta with visibility")
+                continue
+
+            ui_meta = meta.get("ui", {})
+            visibility = ui_meta.get("visibility", [])
+            if "model" in visibility:
+                violations.append(
+                    f"'{tool.name}' - data-only tool should have visibility=['app'], not {visibility}"
+                )
+
+        if data_tools == 0:
+            score = 1.0
+        else:
+            score = 1.0 - (len(violations) / data_tools)
+
+        _report.add_result(GradeResult(
+            category="3. Tool Visibility",
+            check_name="Data-only tools hidden from model",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {data_tools} data-only tools have visibility=['app']" if data_tools else "No data-only tools",
+            weight=1.2,
+            fix_hint="Add _meta={'ui': {'visibility': ['app']}} to data-only tool definitions",
+        ))
+
+    @pytest.mark.asyncio
+    async def test_visibility_values_are_valid(self):
+        """Visibility arrays must contain only 'model' and/or 'app'."""
+        from main import list_tools
+
+        tools = await list_tools()
+        valid_values = {"model", "app"}
+        violations = []
+        checked = 0
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            visibility = ui_meta.get("visibility")
+            if visibility is not None:
+                checked += 1
+                if not isinstance(visibility, list):
+                    violations.append(f"'{tool.name}' - visibility must be a list, got {type(visibility).__name__}")
+                elif not all(v in valid_values for v in visibility):
+                    invalid = [v for v in visibility if v not in valid_values]
+                    violations.append(f"'{tool.name}' - invalid visibility values: {invalid}")
+
+        score = 1.0 - (len(violations) / checked) if checked else 1.0
+        _report.add_result(GradeResult(
+            category="3. Tool Visibility",
+            check_name="Valid visibility values",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Use only ['model'], ['app'], or ['model', 'app'] for visibility",
+        ))
+
+        assert len(violations) == 0, f"Invalid visibility values:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 4. TOOL ANNOTATIONS TESTS
+# =============================================================================
+
+class TestToolAnnotations:
+    """Tests for tool annotations (required for MCP Apps hosts).
+
+    Per the MCP spec and OpenAI App Submission Guidelines, every tool MUST
+    declare these annotations:
+    - readOnlyHint: Does this tool only read data?
+    - destructiveHint: Does this tool delete or irreversibly modify data?
+    - openWorldHint: Does this tool access external/third-party services?
+
+    Incorrect annotations are a TOP REJECTION REASON for ChatGPT Apps.
+    """
+
+    @pytest.mark.asyncio
+    async def test_all_tools_have_annotations(self):
+        """Every tool MUST have readOnlyHint, destructiveHint, and openWorldHint."""
+        from main import list_tools
+
+        tools = await list_tools()
+        required_annotations = {"readOnlyHint", "destructiveHint", "openWorldHint"}
+        violations = []
+
+        for tool in tools:
+            annotations = getattr(tool, 'annotations', None) or {}
+            if isinstance(annotations, dict):
+                missing = required_annotations - set(annotations.keys())
+            else:
+                # Pydantic model annotations
+                anno_dict = annotations.model_dump() if hasattr(annotations, 'model_dump') else {}
+                present = {k for k, v in anno_dict.items() if v is not None}
+                missing = required_annotations - present
+
+            if missing:
+                violations.append(f"'{tool.name}' - missing annotations: {missing}")
+
+        score = 1.0 - (len(violations) / len(tools)) if tools else 0.0
+        _report.add_result(GradeResult(
+            category="4. Tool Annotations",
+            check_name="Required annotations present",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {len(tools)} tools have annotations",
+            weight=2.0,
+            fix_hint="Add annotations={'readOnlyHint': True, 'destructiveHint': False, 'openWorldHint': False} to Tool()",
+        ))
+
+        assert len(violations) == 0, f"Missing annotations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_annotations_are_boolean(self):
+        """Annotation values MUST be boolean (not strings or None)."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+
+        for tool in tools:
+            annotations = getattr(tool, 'annotations', None) or {}
+            if isinstance(annotations, dict):
+                anno_dict = annotations
+            elif hasattr(annotations, 'model_dump'):
+                anno_dict = annotations.model_dump()
+            else:
+                continue
+
+            for key in ["readOnlyHint", "destructiveHint", "openWorldHint"]:
+                val = anno_dict.get(key)
+                if val is not None and not isinstance(val, bool):
+                    violations.append(f"'{tool.name}.{key}' - value {val!r} is not boolean")
+
+        score = 1.0 if len(violations) == 0 else 0.0
+        _report.add_result(GradeResult(
+            category="4. Tool Annotations",
+            check_name="Annotations are boolean",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Use True/False, not strings: 'readOnlyHint': True",
+        ))
+
+        assert len(violations) == 0, f"Non-boolean annotations:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_show_tools_are_read_only(self):
+        """Display tools (show_*) SHOULD be marked readOnlyHint=True.
+
+        Show/display tools don't modify state, so they should be read-only.
+        This helps hosts like ChatGPT auto-approve the tool call.
+        """
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+        show_tools = 0
+
+        for tool in tools:
+            if tool.name.startswith("show_"):
+                show_tools += 1
+                annotations = getattr(tool, 'annotations', None) or {}
+                if isinstance(annotations, dict):
+                    anno_dict = annotations
+                elif hasattr(annotations, 'model_dump'):
+                    anno_dict = annotations.model_dump()
+                else:
+                    anno_dict = {}
+
+                if not anno_dict.get("readOnlyHint", False):
+                    violations.append(f"'{tool.name}' - show_ tool should have readOnlyHint=True")
+                if anno_dict.get("destructiveHint", False):
+                    violations.append(f"'{tool.name}' - show_ tool should NOT have destructiveHint=True")
+
+        score = 1.0 - (len(violations) / show_tools) if show_tools else 1.0
+        _report.add_result(GradeResult(
+            category="4. Tool Annotations",
+            check_name="Show tools are read-only",
+            passed=len(violations) == 0,
+            score=max(0, score),
+            details="\n".join(violations) if violations else f"All {show_tools} show_ tools marked read-only",
+            weight=1.5,
+            fix_hint="Set read_only=True in Widget() or annotations={'readOnlyHint': True} in Tool()",
+        ))
+
+        assert len(violations) == 0, f"Annotation mismatch:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 5. CSP COMPLETENESS TESTS
+# =============================================================================
+
+class TestCSPCompleteness:
+    """Tests for Content Security Policy configuration.
+
+    SEP-1865 stable spec defines four CSP domain lists:
+    - resourceDomains: For scripts, styles, images, fonts
+    - connectDomains: For fetch/XHR requests
+    - frameDomains: For nested iframes
+    - baseUriDomains: For base URI resolution
+
+    All four SHOULD be present (empty lists are fine for unused categories).
+    """
+
+    @pytest.mark.asyncio
+    async def test_csp_has_all_domain_lists(self):
+        """CSP configuration SHOULD include all four domain lists."""
+        from main import list_tools
+
+        tools = await list_tools()
+        required_lists = {"resourceDomains", "connectDomains", "frameDomains", "baseUriDomains"}
+        violations = []
+        checked = 0
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            csp = ui_meta.get("csp")
+            if not csp:
+                continue
+
+            checked += 1
+            if isinstance(csp, dict):
+                missing = required_lists - set(csp.keys())
+                if missing:
+                    violations.append(f"'{tool.name}' - CSP missing: {missing}")
+
+        score = 1.0 - (len(violations) / checked) if checked else 0.0
+        _report.add_result(GradeResult(
+            category="5. CSP Completeness",
+            check_name="All four CSP domain lists",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {checked} tools have complete CSP",
+            weight=1.5,
+            fix_hint="Add frameDomains: [] and baseUriDomains: [origin] to get_csp_domains()",
+        ))
+
+        assert len(violations) == 0, f"Incomplete CSP:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_csp_resource_domains_include_server(self):
+        """CSP resourceDomains MUST include the server's own origin."""
+        from main import list_tools
+        from widgets._base import get_base_url
+
+        tools = await list_tools()
+        base_url = get_base_url()
+        parsed = urlparse(base_url)
+        server_origin = f"{parsed.scheme}://{parsed.netloc}"
+
+        violations = []
+        checked = 0
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            csp = ui_meta.get("csp", {})
+            resource_domains = csp.get("resourceDomains", [])
+            if resource_domains:
+                checked += 1
+                if server_origin not in resource_domains:
+                    violations.append(
+                        f"'{tool.name}' - resourceDomains missing server origin '{server_origin}'"
+                    )
+
+        score = 1.0 - (len(violations) / checked) if checked else 0.0
+        _report.add_result(GradeResult(
+            category="5. CSP Completeness",
+            check_name="Server origin in resourceDomains",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Include server origin in resourceDomains for self-hosted assets",
+        ))
+
+        assert len(violations) == 0, f"Missing server origin:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 6. TEXT FALLBACK TESTS
+# =============================================================================
+
+class TestTextFallback:
+    """Tests for text-only fallback (portability).
+
+    Per SEP-1865 and the "Build for portability" best practice, tools MUST
+    provide text content alongside structuredContent. Hosts that don't support
+    MCP Apps will only see the text content array.
+
+    This is a TOP REJECTION REASON: if your tool only returns structuredContent
+    without text content, it breaks on non-UI hosts.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tools_have_text_content(self):
+        """Tool results MUST include content[] with TextContent for non-UI hosts."""
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            content = result.root.content
+            if not content:
+                violations.append(f"'{widget.identifier}' - missing content[] (no text fallback)")
+            else:
+                has_text = any(
+                    getattr(c, 'type', None) == 'text' and getattr(c, 'text', '').strip()
+                    for c in content
+                )
+                if not has_text:
+                    violations.append(f"'{widget.identifier}' - content[] has no non-empty TextContent")
+
+        score = 1.0 - (len(violations) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="6. Text Fallback",
+            check_name="Text content for non-UI hosts",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {len(WIDGETS)} tools provide text fallback",
+            weight=2.0,
+            fix_hint="Include content=[types.TextContent(type='text', text='Summary...')] in CallToolResult",
+        ))
+
+        assert len(violations) == 0, f"Missing text fallback:\n" + "\n".join(violations)
+
+    @pytest.mark.asyncio
+    async def test_text_content_is_meaningful(self):
+        """Text fallback should be a meaningful summary, not just 'OK' or the tool name."""
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+        trivial_responses = {'ok', 'success', 'done', 'ready', 'loaded', ''}
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            content = result.root.content
+            if content:
+                for c in content:
+                    if getattr(c, 'type', None) == 'text':
+                        text = getattr(c, 'text', '').strip().lower()
+                        if text in trivial_responses:
+                            violations.append(
+                                f"'{widget.identifier}' - trivial text content: '{text}'"
+                            )
+                        elif len(text) < 10:
+                            violations.append(
+                                f"'{widget.identifier}' - text content too short ({len(text)} chars)"
+                            )
+
+        score = 1.0 - (len(violations) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="6. Text Fallback",
+            check_name="Meaningful text summary",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.0,
+            fix_hint="Return a useful summary: 'Carousel with 5 items: Photo Gallery' not just 'OK'",
+        ))
+
+        # Soft check - contributes to grade but doesn't fail
+        # assert len(violations) == 0
+
+
+# =============================================================================
+# 7. INVOCATION METADATA TESTS
+# =============================================================================
+
+class TestInvocationMetadata:
+    """Tests for tool invocation result metadata.
+
+    Per SEP-1865, tool results SHOULD include _meta.ui with:
+    - resourceUri: Links result to the UI resource for rendering
+    - csp: CSP domains for the sandbox
+    """
+
+    @pytest.mark.asyncio
+    async def test_results_have_meta_ui(self):
+        """Tool results SHOULD include _meta.ui.resourceUri for rendering."""
+        from main import handle_call_tool, WIDGETS
+
+        violations = []
+
+        for widget in WIDGETS:
+            request = types.CallToolRequest(
+                method="tools/call",
+                params=types.CallToolRequestParams(
+                    name=widget.identifier,
+                    arguments={},
+                ),
+            )
+            result = await handle_call_tool(request)
+
+            meta = getattr(result.root, '_meta', None) or getattr(result.root, 'meta', None)
+            if not meta:
+                violations.append(f"'{widget.identifier}' - result missing _meta")
+                continue
+
+            ui_meta = meta.get("ui") if isinstance(meta, dict) else None
+            if not ui_meta:
+                violations.append(f"'{widget.identifier}' - result missing _meta.ui")
+            elif "resourceUri" not in ui_meta:
+                violations.append(f"'{widget.identifier}' - result _meta.ui missing resourceUri")
+
+        score = 1.0 - (len(violations) / len(WIDGETS)) if WIDGETS else 0.0
+        _report.add_result(GradeResult(
+            category="7. Invocation Metadata",
+            check_name="Result _meta.ui.resourceUri",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else "",
+            weight=1.5,
+            fix_hint="Include _meta=get_invocation_meta(widget) in CallToolResult",
+        ))
+
+        assert len(violations) == 0, f"Missing result metadata:\n" + "\n".join(violations)
+
+
+# =============================================================================
+# 8. PREFERS BORDER TESTS
+# =============================================================================
+
+class TestPrefersBorder:
+    """Tests for the prefersBorder UI preference (SEP-1865 stable).
+
+    The prefersBorder field hints to hosts about whether the widget
+    should have a visual boundary (border/shadow). This is optional
+    but recommended for a polished appearance.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tools_declare_prefers_border(self):
+        """Widget tools SHOULD declare prefersBorder in _meta.ui."""
+        from main import list_tools
+
+        tools = await list_tools()
+        violations = []
+        widget_tools = 0
+
+        for tool in tools:
+            meta = getattr(tool, '_meta', None) or getattr(tool, 'meta', None)
+            if not meta or not isinstance(meta, dict):
+                continue
+            ui_meta = meta.get("ui", {})
+            if "resourceUri" not in ui_meta:
+                continue
+
+            widget_tools += 1
+            if "prefersBorder" not in ui_meta:
+                violations.append(f"'{tool.name}' - missing _meta.ui.prefersBorder")
+
+        score = 1.0 - (len(violations) / widget_tools) if widget_tools else 0.0
+        _report.add_result(GradeResult(
+            category="8. UI Preferences",
+            check_name="prefersBorder declared",
+            passed=len(violations) == 0,
+            score=score,
+            details="\n".join(violations) if violations else f"All {widget_tools} tools declare prefersBorder",
+            weight=0.5,
+            fix_hint="Add 'prefersBorder': True to _meta.ui in get_tool_meta()",
+        ))
+
+        # Soft check
+        # assert len(violations) == 0
+
+
+# =============================================================================
+# REPORT GENERATION
+# =============================================================================
+
+class TestGenerateReport:
+    """Final test to generate the compliance report."""
+
+    def test_zzz_generate_protocol_compliance_report(self, capsys):
+        """Generate final compliance report (zzz_ prefix ensures it runs last)."""
+        report = _report.generate_report()
+        print("\n" + report)
+
+        report_path = Path(__file__).parent / "protocol_compliance_report.txt"
+        report_path.write_text(report)
+
+        overall = _report.get_overall_score()
+        grade = _report.get_grade_letter()
+
+        # Protocol compliance must be B or better (80%)
+        assert overall >= 80, f"""
+PROTOCOL COMPLIANCE: {grade} ({overall:.1f}%) - Below 80% threshold
+This means the server does not fully comply with SEP-1865.
+Report: server/tests/protocol_compliance_report.txt
+Spec: docs/mcp-apps-specs.mdx
+"""

--- a/server/widgets/_base.py
+++ b/server/widgets/_base.py
@@ -21,6 +21,12 @@ class Widget:
     invoking: str
     invoked: str
     component_name: str
+    # Tool annotations (SEP-1865 stable spec, 2026-01-26)
+    read_only: bool = True
+    destructive: bool = False
+    open_world: bool = False
+    # UI preferences
+    prefers_border: bool = True
 
 
 ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
@@ -119,6 +125,12 @@ def get_csp_domains() -> Dict[str, List[str]]:
 
     This allows the MCP App sandbox to load external assets (JS, CSS, images)
     from our server and from external CDNs.
+
+    SEP-1865 stable spec (2026-01-26) defines four CSP domain lists:
+    - resourceDomains: scripts, styles, images, fonts
+    - connectDomains: fetch/XHR requests
+    - frameDomains: nested iframes (e.g., embedded maps, videos)
+    - baseUriDomains: allowed base URIs for relative URL resolution
     """
     base_url = get_base_url()
     # Extract origin from base URL (e.g., "http://localhost:8000" from "http://localhost:8000/assets")
@@ -132,6 +144,8 @@ def get_csp_domains() -> Dict[str, List[str]]:
     return {
         "resourceDomains": resource_domains,  # For scripts, styles, images, fonts
         "connectDomains": connect_domains,    # For fetch/XHR requests
+        "frameDomains": [],                   # Nested iframes (add domains if needed)
+        "baseUriDomains": [origin],           # Base URI for relative URL resolution
     }
 
 
@@ -140,22 +154,45 @@ def get_tool_meta(widget: Widget) -> Dict[str, Any]:
 
     The key field is `ui.resourceUri` which links the tool to its UI resource.
     The `csp` field specifies Content Security Policy domains for the sandbox.
-    This follows the MCP Apps protocol specification.
+    The `visibility` field controls who can call the tool (model, app, or both).
+    The `prefersBorder` field hints to hosts about visual boundary preference.
+    This follows the MCP Apps protocol specification (SEP-1865 stable, 2026-01-26).
     """
     return {
         "ui": {
             "resourceUri": widget.template_uri,
+            "visibility": ["model", "app"],
             "csp": get_csp_domains(),
+            "prefersBorder": widget.prefers_border,
+        },
+    }
+
+
+def get_data_only_tool_meta() -> Dict[str, Any]:
+    """Return MCP Apps metadata for data-only tools (called by widgets, not LLM).
+
+    Data-only tools have visibility=["app"] so MCP hosts hide them from the
+    model's tool list. They are only callable via widget callTool invocations.
+    """
+    return {
+        "ui": {
+            "visibility": ["app"],
         },
     }
 
 
 def get_invocation_meta(widget: Widget) -> Dict[str, Any]:
-    """Return metadata for tool invocation results."""
+    """Return metadata for tool invocation results.
+
+    Per SEP-1865, content-item _meta.ui takes precedence over listing-level
+    metadata. We include full CSP and visibility here for completeness.
+    """
     return {
         "ui": {
             "resourceUri": widget.template_uri,
+            "visibility": ["model", "app"],
             "csp": get_csp_domains(),
+            "prefersBorder": widget.prefers_border,
         },
     }
 


### PR DESCRIPTION
## Summary

- **Protocol compliance**: Updates the template to fully comply with the stable MCP Apps spec (SEP-1865, 2026-01-26) — adds tool visibility, expanded CSP (frameDomains, baseUriDomains), prefersBorder, per-widget annotations, and data-only tool meta routing
- **New test suite: `test_protocol_compliance.py`** — 17 hard compliance checks covering resource registration, tool-UI linkage, visibility, annotations, CSP completeness, text fallback, invocation metadata, and UI preferences
- **New test suite: `test_app_submission.py`** — 13 submission readiness checks based on OpenAI App Submission Guidelines and recent Anthropic/MCP blog posts, covering annotation correctness, stability, token efficiency, capability focus, cold start experience, and cross-host portability
- **Fixes existing tests** that broke when data-only tools gained `_meta.ui` for visibility routing

### Results
| Report | Grade |
|--------|-------|
| Protocol Compliance | **A (100%)** |
| App Submission Readiness | **A (99%)** |
| MCP Best Practices | A |
| ChatGPT App Guidelines | A |
| Output Quality | A |
| Agentic UX Patterns | A |

All **227 server tests + 274 UI tests** pass.

## Test plan
- [x] `pnpm run test:server` — 227 passed
- [x] `pnpm run test:ui` — 274 passed  
- [ ] `pnpm run test:browser` — requires Playwright setup (not run in this env)
- [ ] Manual: verify widgets render correctly in ChatGPT/Claude after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)